### PR TITLE
fix: Correct SAM template !Sub syntax for TelegramBotApiEndpoint

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -22,18 +22,18 @@ Parameters:
 Globals:
   Function:
     Timeout: 30
-    MemorySize: 256 # Can be adjusted based on needs
+    MemorySize: 256
 
 Resources:
   TelegramBotFunction:
     Type: AWS::Serverless::Function
     Properties:
-      PackageType: Zip # MODIFIED
-      Handler: lambda_function.lambda_handler # MODIFIED (points to src/lambda_function.py, function lambda_handler)
-      Runtime: python3.9 # MODIFIED
-      CodeUri: src/ # MODIFIED (points to the directory containing the handler)
-      Architectures: # Can often be omitted for Zip, but good to specify if known
-        - x86_64 # or arm64 if preferred and supported by runtime
+      PackageType: Zip
+      Handler: lambda_function.lambda_handler
+      Runtime: python3.9
+      CodeUri: src/
+      Architectures:
+        - x86_64
       Environment:
         Variables:
           TELEGRAM_BOT_TOKEN: !Ref TelegramBotToken
@@ -46,13 +46,13 @@ Resources:
           Properties:
             Path: /webhook
             Method: post
-            RestApiId: !Serverless::Api # Implicitly creates an API Gateway
-    # REMOVED Metadata section that contained DockerTag, DockerContext, Dockerfile
+            RestApiId: !Serverless::Api
+    # Metadata section removed for Zip deployment
 
 Outputs:
   TelegramBotApiEndpoint:
     Description: "API Gateway endpoint URL for your Telegram Bot Webhook. Register this URL with Telegram and provide the Webhook Secret Token."
-    Value: !Sub "https://\${ServerlessRestApi}.execute-api.\${AWS::Region}.amazonaws.com/\${Serverless::Stage}/webhook"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/${Serverless::Stage}/webhook" # ACTUAL CORRECT LINE
   TelegramBotFunctionArn:
     Description: "Telegram Bot Lambda Function ARN"
     Value: !GetAtt TelegramBotFunction.Arn


### PR DESCRIPTION
This commit resolves a persistent parsing error in `template.yaml` caused by incorrect escaping within the `!Sub` function for the `Outputs.TelegramBotApiEndpoint.Value` line.

The backslashes preceding `${ServerlessRestApi}`, `${AWS::Region}`, and `${Serverless::Stage}` have been removed, ensuring correct CloudFormation/SAM variable substitution. The line is now: `Value: !Sub "https://\${ServerlessRestApi}.execute-api.\${AWS::Region}.amazonaws.com/\${Serverless::Stage}/webhook"`

This should allow `sam build` to parse the template successfully.