### PR TITLE
fix: Definitive correction of SAM template !Sub syntax

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -46,13 +46,13 @@ Resources:
           Properties:
             Path: /webhook
             Method: post
-            RestApiId: !Ref ServerlessRestApi # MODIFIED LINE
+            RestApiId: !Ref ServerlessRestApi
     # Metadata section removed for Zip deployment
 
 Outputs:
   TelegramBotApiEndpoint:
     Description: "API Gateway endpoint URL for your Telegram Bot Webhook. Register this URL with Telegram and provide the Webhook Secret Token."
-    Value: !Sub "https://\${ServerlessRestApi}.execute-api.\${AWS::Region}.amazonaws.com/\${Serverless::Stage}/webhook"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/${Serverless::Stage}/webhook"
   TelegramBotFunctionArn:
     Description: "Telegram Bot Lambda Function ARN"
     Value: !GetAtt TelegramBotFunction.Arn


### PR DESCRIPTION
This commit ensures the `Outputs.TelegramBotApiEndpoint.Value` line in `template.yaml` uses the correct `!Sub` syntax without any erroneous backslashes before CloudFormation/SAM variable placeholders.

The line is now definitively:
`Value: !Sub "https://\${ServerlessRestApi}.execute-api.\${AWS::Region}.amazonaws.com/\${Serverless::Stage}/webhook"`

This is intended to resolve persistent `sam build` parsing errors related to this line.