### PR TITLE
fix: Add CAPABILITY_IAM to sam deploy and update README

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,6 +40,7 @@ jobs:
             --no-fail-on-empty-changeset \
             --s3-bucket ${{ vars.SAM_CLI_S3_BUCKET }} \
             --s3-prefix telegram-bot-deployments \
+            --capabilities CAPABILITY_IAM \
             --parameter-overrides \
               ParameterKey=TelegramBotToken,ParameterValue='${{ secrets.TELEGRAM_BOT_TOKEN }}' \
               ParameterKey=AuthorizedUserIds,ParameterValue='${{ vars.AUTHORIZED_USER_IDS }}' \

--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ Create an IAM role in your AWS account that GitHub Actions can assume.
 *   **GitHub organization/repository/username**: Specify your GitHub details to restrict which workflows can assume this role.
 *   **Permissions**: Attach policies that grant necessary permissions for SAM deployments. This includes permissions for CloudFormation, Lambda, API Gateway, IAM (to pass roles), and **S3 (PutObject, GetObject for the SAM deployment bucket)**. Apply the principle of least privilege.
 
+    *Note: The SAM template creates an IAM role for the Lambda function, which is why `CAPABILITY_IAM` is used during deployment.*
+
 Store the ARN of this role in the `AWS_IAM_ROLE_FOR_GITHUB_ACTIONS` GitHub secret.
 
 ### 6. Deployment via GitHub Actions
@@ -123,7 +125,7 @@ Your bot is now live!
     ```bash
     sam deploy --guided
     ```
-    This will prompt you for parameters, including the S3 bucket for deployment. For local testing, you can enter values directly.
+    (This will prompt you for parameters, including the S3 bucket for deployment. For local testing, you can enter values directly. Note: if the stack creates IAM resources, you might need to add `--capabilities CAPABILITY_IAM` if deploying manually without `--guided` which handles this.)
 6.  **Local Invocation (for `lambda_function.py`):**
     You can test the Lambda function locally using `sam local invoke`.
 


### PR DESCRIPTION
This commit addresses the 'Requires capabilities : [CAPABILITY_IAM]' error you encountered during `sam deploy`.

Changes include:
- Modified `.github/workflows/deploy.yml`:
  - Added the `--capabilities CAPABILITY_IAM` flag to the `sam deploy` command. This explicitly acknowledges that the CloudFormation stack creates IAM resources (specifically, the Lambda execution role).
- Updated `README.md`:
  - Added notes explaining the purpose of `CAPABILITY_IAM` in the context of the SAM deployment, both for the automated workflow and for users performing manual local deployments.