### PR TITLE
Fix: Use sync wrapper for lambda_handler to resolve coroutine error

### DIFF
--- a/src/lambda_function.py
+++ b/src/lambda_function.py
@@ -1,5 +1,5 @@
 import json
-import asyncio
+import asyncio # This was already present, kept as is.
 import os
 import logging
 from telegram import Update, Bot
@@ -31,7 +31,7 @@ async def initialize_bot():
         logger.info("Bot application initialized and handlers registered.")
     return application
 
-async def lambda_handler(event, context):
+async def actual_async_logic(event, context): # Renamed from lambda_handler
     try:
         logger.info(f"Received event: {json.dumps(event)}")
 
@@ -73,3 +73,7 @@ async def lambda_handler(event, context):
     except Exception as e:
         logger.error(f"Error processing update: {e}", exc_info=True)
         return {'statusCode': 500, 'body': json.dumps({'message': f"Internal server error: {str(e)}"})}
+
+# New lambda_handler function
+def lambda_handler(event, context):
+    return asyncio.run(actual_async_logic(event, context))


### PR DESCRIPTION
The Lambda function was failing with:
Runtime.MarshalError: Unable to marshal response: Object of type coroutine is not JSON serializable RuntimeWarning: coroutine 'lambda_handler' was never awaited

This indicates that the AWS Lambda runtime was not correctly awaiting the async def lambda_handler, despite the Python 3.9 runtime normally supporting this.

To ensure correct execution and prevent the error, the lambda_handler is now a synchronous function that calls asyncio.run() on the core asynchronous logic (renamed to actual_async_logic). This explicitly manages the asyncio event loop for the handler's execution, ensuring that a JSON-serializable response is returned to the Lambda runtime.