### PR TITLE
Fix: Ensure Telegram Application is initialized

### DIFF
--- a/src/lambda_function.py
+++ b/src/lambda_function.py
@@ -26,6 +26,7 @@ async def initialize_bot():
         logger.info("Initializing bot application for Lambda...")
         bot = Bot(token=TELEGRAM_BOT_TOKEN)
         application = Application.builder().bot(bot).build()
+        await application.initialize() # <-- ADDED THIS LINE
         application.add_handler(CommandHandler("start", start))
         application.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, handle_message))
         logger.info("Bot application initialized and handlers registered.")


### PR DESCRIPTION
The previous deployment failed with:
RuntimeError: This Application was not initialized via `Application.initialize`!

This error occurs when Application.process_update() is called before the Application object has been fully initialized with an explicit call to `await application.initialize()`. This is a requirement for python-telegram-bot v20+.

This commit adds `await application.initialize()` to the `initialize_bot` function, after the Application instance is built and before handlers are added. This ensures the application is properly set up before use. The call is within the existing singleton check to ensure it only runs once per Lambda container lifecycle.