### PR TITLE
Fix: Enable reposting of polls by adding dedicated poll handler

### DIFF
--- a/src/lambda_function.py
+++ b/src/lambda_function.py
@@ -41,7 +41,9 @@ async def initialize_bot():
 
         application.add_handler(CommandHandler("start", start))
         application.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, handle_message))
-        logger.info("Bot application initialized and handlers registered.")
+        # Add a handler for polls
+        application.add_handler(MessageHandler(filters.POLL, handle_message))
+        logger.info("Bot application initialized and handlers registered for text and poll messages.")
     logger.info("Finished initialize_bot().")
     return application
 


### PR DESCRIPTION
Previously, poll messages were not processed because no specific handler was registered for them. This change adds a MessageHandler for `filters.POLL` in `lambda_function.py`, directing poll updates to the existing `handle_message` function in `main.py`.

The `handle_message` function already contained the necessary logic to identify and forward polls from authorized users, so no changes were needed there.