### PR TITLE
Refactor: Remove comments and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,8 +164,20 @@ Your bot is now live!
 *   **Webhook Verification:** The bot uses a `TELEGRAM_WEBHOOK_SECRET_TOKEN` for security.
 *   **IAM Permissions:** Follow the principle of least privilege.
 
-## Code Style and Comments
+## Code Style and Documentation
 
-- Avoid adding comments that merely restate what the code does. Focus on *why* a particular implementation detail was chosen if it's not obvious.
-- Verbose explanations of straightforward code sections should be avoided. Commit messages are a good place for detailed history of changes.
-- Keep comments concise and targeted at clarifying complexity or non-obvious logic.
+The codebase aims for clarity and readability, minimizing inline comments that merely restate what the code does.
+- **Minimal Comments:** Comments are generally avoided unless they clarify non-obvious logic that cannot be made clear by the code itself.
+- **README for Complexity:** More complex behaviors, architectural decisions, or known limitations (such as placeholder functions) are documented in this README file.
+- **Commit Messages:** Detailed history of changes and the rationale behind them should be captured in commit messages.
+
+## Known Limitations and Important Notes
+
+*   **`find_bot_last_message_in_channel` Function (in `src/main.py`):**
+    *   The current implementation of `find_bot_last_message_in_channel` is a **placeholder**. It logs a warning and returns `None`.
+    *   This function is intended to find the last message posted by the bot in the target channel, which is crucial for the poll-linking feature (editing the bot's last announcement to add a poll link).
+    *   **Action Required:** To enable the poll-linking functionality as described, this function needs to be replaced with a working implementation that can fetch recent messages from the target channel. This might involve:
+        *   Using a specific method from the `python-telegram-bot` library if available and if the bot has sufficient permissions (e.g., admin rights in the channel).
+        *   Making direct Telegram Bot API calls if the library does not directly support the required message fetching capability.
+        *   Considering alternative strategies if direct fetching is not feasible (e.g., the bot remembering its own message IDs if it's guaranteed to be the only one posting or has a way to identify its messages).
+    *   The current behavior means that when a user sends a poll, the bot will likely log that it couldn't find its last message and will not proceed to link the poll to any previous announcement.

--- a/src/main.py
+++ b/src/main.py
@@ -4,8 +4,6 @@ import json
 from telegram import Update, Bot
 from telegram.ext import Application, CommandHandler, MessageHandler, filters, ContextTypes
 
-# Configure logging for when running main.py directly
-# Lambda will have its own logging configuration.
 if __name__ == '__main__':
     logging.basicConfig(
         format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
@@ -13,104 +11,45 @@ if __name__ == '__main__':
     )
 logger = logging.getLogger(__name__)
 
-import datetime # For timedelta and timezone
-from datetime import datetime as RealDatetimeClass # Alias for type checking
+import datetime
+from datetime import datetime as RealDatetimeClass
 from datetime import timedelta
-import re # For potential string manipulation
-import json # For logging structured data
-from typing import Optional # Added for Python 3.9 compatibility
+import re
+import json
+from typing import Optional
 
-# Environment variables
 TELEGRAM_BOT_TOKEN = os.environ.get('TELEGRAM_BOT_TOKEN')
 AUTHORIZED_USER_IDS = [int(user_id) for user_id in os.environ.get('AUTHORIZED_USER_IDS', '').split(',') if user_id]
 TARGET_CHANNEL_ID = os.environ.get('TARGET_CHANNEL_ID')
 KEYWORDS = ["#анонс", "#опрос"]
 
-# Templates for messages that link to forwarded polls
 POLL_LINK_MESSAGE_TEMPLATES = {
     "#анонс": "Проголосуй <a href=\"{link}\">здесь</a>, если придёшь (ну или хотя бы рассматриваешь такую возможность)",
     "#опрос": "<a href=\"{link}\">Проголосуй тут</a>"
 }
-# Identifiers to check if a poll's caption (after forwarding) already contains a poll prompt
-# This helps decide whether to edit the caption or send a new message.
-POLL_CAPTION_IDENTIFIERS = [ # Not currently used, BOT_POLL_PROMPT_STARTS is used instead
+POLL_CAPTION_IDENTIFIERS = [
     "Проголосуй <a href=",
     "<a href=",
 ]
 
-# Helper strings for identifying bot's own poll prompts
 BOT_POLL_PROMPT_STARTS = [
     "Проголосуй <a href=",
-    "<a href=" # For the #опрос template specifically
+    "<a href="
 ]
 
-# For simplicity with user_data, let's define a key
 LAST_ANNOUNCEMENT_KEY = 'last_announcement_details'
 
 async def start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-    """Sends a welcome message when the /start command is issued."""
     user_id = update.effective_user.id
     logger.info(f"Received /start command from user ID: {user_id}.")
     await update.message.reply_text('Hello! I am ready to monitor messages.')
     logger.info(f"Welcome message sent to user ID: {user_id}.")
 
-# Note: The duplicate definitions of BOT_POLL_PROMPT_STARTS and LAST_ANNOUNCEMENT_KEY
-# that were here have been removed. Their primary definitions are at the top of the file.
-
 async def find_bot_last_message_in_channel(bot: Bot, channel_id: str, max_age_hours: int = 1, search_limit: int = 20) -> Optional[dict]:
-    """
-    Tries to find the last message posted by the bot itself in the specified channel.
-
-    Args:
-        bot: The telegram.Bot instance.
-        channel_id: The ID of the target channel.
-        max_age_hours: Maximum age of the message in hours.
-        search_limit: How many recent messages to search through.
-
-    Returns:
-        A dictionary with 'message_id' and 'text_content' if found, else None.
-    """
     logger.info(f"Searching for bot's last message in channel {channel_id} (search limit: {search_limit} messages, max age: {max_age_hours}h).")
     bot_id = bot.id
     try:
-        # IMPORTANT: bot.get_chat_messages is NOT a standard method in python-telegram-bot.
-        # This is a conceptual placeholder for whatever method is used to fetch recent channel messages.
-        # This might require the bot to be an admin and use a more complex search or specific library features
-        # if available, or the user might have a specific way to do this.
-        # A common approach for bots if not admin is to process 'channel_post' updates as they arrive,
-        # but this function attempts an on-demand fetch as per user suggestion.
-        #
-        # If a direct method like this isn't available, this function would need significant changes
-        # or rely on the bot having administrator privileges to search messages effectively.
-        # For example, one might need to use a raw API call if the library doesn't wrap it.
-        #
-        # messages = await bot.get_chat_messages(chat_id=channel_id, limit=search_limit, offset_id=0, offset_date=0, etc...)
-        # ^^^ THIS IS PSEUDOCODE for fetching messages ^^^
-
-        # For the purpose of this exercise, and without a concrete API call that's guaranteed to work
-        # for all bot permission levels, this function will currently return None.
-        # The user will need to replace the message fetching part with a working solution
-        # based on their bot's capabilities and the `python-telegram-bot` version/extensions they might use.
-
         logger.warning(f"Message fetching part of find_bot_last_message_in_channel is a placeholder. It needs a real implementation.")
-        # Simulate fetching - replace this with actual API call
-        # Example of what the loop would do if `channel_messages` was populated:
-        # channel_messages = [] # Actual fetched messages would go here
-        # for msg in reversed(channel_messages): # Assuming messages are newest first if limit applied, or sort them
-        #    if msg.from_user and msg.from_user.id == bot_id:
-        #        message_age = datetime.datetime.now(datetime.timezone.utc) - msg.date
-        #        if message_age <= timedelta(hours=max_age_hours):
-        #            logger.info(f"Found bot's message (ID: {msg.message_id}, Age: {message_age}) within {max_age_hours}h.")
-        #            return {'message_id': msg.message_id, 'text_content': msg.text}
-        #        else:
-        #            logger.info(f"Found bot's message (ID: {msg.message_id}), but it's too old (Age: {message_age}).")
-        #            return None # Found our message, but it's too old. Stop searching.
-        #    elif msg.sender_chat and msg.sender_chat.id == int(channel_id): # For anonymous admin bot posts
-        #        # This case is harder as sender_chat.id is the channel_id if bot posts as channel
-        #        # We might need to check content or rely on it being the only recent message
-        #        pass
-
-        # Returning None as placeholder behavior
         return None
 
     except Exception as e:
@@ -163,7 +102,6 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
         return
     logger.info(f"User {user.id} is authorized.")
 
-    # CASE 1: User sends a TEXT MESSAGE with a keyword (and it's not a poll)
     if message.text and not message.poll:
         found_keyword_in_text = None
         for kw in KEYWORDS:
@@ -183,15 +121,11 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
                 logger.info(f"Posting text announcement to {TARGET_CHANNEL_ID}: \"{text_to_repost[:100]}...\"")
                 posted_announcement = await context.bot.send_message(chat_id=TARGET_CHANNEL_ID, text=text_to_repost)
                 logger.info(f"Successfully posted text announcement with ID {posted_announcement.message_id}.")
-                # No longer storing announcement details in user_data for this flow
-                # context.user_data[LAST_ANNOUNCEMENT_KEY] = announcement_details_to_store
-                # logger.info(f"Stored announcement details in user_data for user {user.id}, key '{LAST_ANNOUNCEMENT_KEY}': {json.dumps(announcement_details_to_store, default=str)}")
             except Exception as e:
                 logger.error(f"Error posting text announcement for keyword '{found_keyword_in_text}': {e}", exc_info=True)
                 await message.reply_text(f"Sorry, error posting your announcement: {e}")
             return
 
-    # CASE 2: User sends a POLL OBJECT to the bot
     elif message.poll:
         logger.info(f"Received a poll object (msg_id: {message.message_id}) from user {user.id}. Attempting to edit last announcement.")
         if not TARGET_CHANNEL_ID:
@@ -199,7 +133,6 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
             await message.reply_text("Error: Target channel ID is not configured for polls.")
             return
 
-        # Age Check for the original user's poll message
         now = datetime.datetime.now(datetime.timezone.utc)
         original_poll_date = message.date
         if not isinstance(original_poll_date, RealDatetimeClass):
@@ -209,18 +142,16 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
             logger.info(f"Original poll (ID: {message.message_id}) is older than 1 hour. Skipping poll prompt.")
             return
 
-        # New logic: Find the bot's last message in the target channel
         logger.info(f"Attempting to find bot's last message in channel {TARGET_CHANNEL_ID} to attach poll link.")
 
         last_bot_message_details = await find_bot_last_message_in_channel(
             bot=context.bot,
             channel_id=TARGET_CHANNEL_ID,
-            max_age_hours=1  # As per user's requirement
+            max_age_hours=1
         )
 
         if not last_bot_message_details:
             logger.warning(f"Could not find a recent message from the bot (or it was too old) in channel {TARGET_CHANNEL_ID}. Cannot attach poll link.")
-            # Optionally, inform user: await message.reply_text("I couldn't find my last announcement to attach the poll to.")
             return
 
         logger.info(f"Found bot's last message: ID {last_bot_message_details['message_id']}, Text: \"{last_bot_message_details['text_content'][:50]}...\"")
@@ -228,9 +159,8 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
         base_announcement_text = last_bot_message_details['text_content']
         target_message_id_to_edit = last_bot_message_details['message_id']
 
-        # Determine Poll Prompt Text based on keywords in original poll's caption
-        chosen_keyword_for_template = "#анонс" # Default
-        if message.text: # Poll caption
+        chosen_keyword_for_template = "#анонс"
+        if message.text:
             logger.info(f"Poll has caption: \"{message.text[:100]}...\"")
             for kw in KEYWORDS:
                 if kw.lower() in message.text.lower():
@@ -240,64 +170,49 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
         else:
             logger.info(f"No caption in poll. Defaulting to '{chosen_keyword_for_template}' template for message {target_message_id_to_edit}.")
 
-        # Prepare link to the original user's poll message
         link_to_original_poll = ""
         if message.chat.username:
             link_to_original_poll = f"https://t.me/{message.chat.username}/{message.message_id}"
         elif str(message.chat_id).startswith("-100"):
-            numeric_chat_id = str(message.chat_id)[4:] # Strip -100 prefix
+            numeric_chat_id = str(message.chat_id)[4:]
             link_to_original_poll = f"https://t.me/c/{numeric_chat_id}/{message.message_id}"
-        else: # Attempt for other private/group chats if possible, log warning
+        else:
             logger.warning(f"Poll is from chat ID {message.chat_id} (type: {message.chat.type}), username: {message.chat.username}. Public link generation might be unreliable.")
             if message.chat.type == "private":
                  logger.warning(f"Cannot create a public link for a poll from a private chat with user {user.id}.")
                  await message.reply_text("For polls from private chat, I can't make a public link. Please use a group/channel.")
-                 # No user_data to pop here anymore
                  return
-            elif str(message.chat_id).startswith("-"): # Non-supergroup, e.g. -12345
+            elif str(message.chat_id).startswith("-"):
                  stripped_chat_id = str(message.chat_id).lstrip("-")
                  link_to_original_poll = f"https://t.me/c/{stripped_chat_id}/{message.message_id}"
                  logger.info(f"Attempting /c/ link for non-supergroup private chat: {link_to_original_poll}")
-            else: # Other cases, like bot's own chat if it's not a group/channel
+            else:
                  logger.error(f"Cannot determine a shareable link for poll from chat {message.chat_id} (type {message.chat.type}).")
                  await message.reply_text("Cannot create a shareable link for this poll's location.")
-                 # context.user_data.pop(LAST_ANNOUNCEMENT_KEY, None) # No longer using user_data for this
-                 # logger.info(f"Popped '{LAST_ANNOUNCEMENT_KEY}' from user_data as poll link cannot be generated.") # No longer using user_data for this
                  return
 
         logger.info(f"Generated poll link: {link_to_original_poll}")
 
-        if not link_to_original_poll: # Should be caught by earlier returns, but as a safeguard
+        if not link_to_original_poll:
              logger.error(f"Link generation failed unexpectedly for poll {message.message_id} from chat {message.chat_id}.")
              await message.reply_text("Sorry, I could not generate a link for your poll.")
-             # context.user_data.pop(LAST_ANNOUNCEMENT_KEY, None) # No longer using user_data for this
-             # logger.info(f"Popped '{LAST_ANNOUNCEMENT_KEY}' from user_data due to link generation failure.") # No longer using user_data for this
              return
 
         new_poll_prompt_segment = POLL_LINK_MESSAGE_TEMPLATES[chosen_keyword_for_template].format(link=link_to_original_poll)
         logger.info(f"New poll prompt segment: \"{new_poll_prompt_segment}\"")
 
-        # Logic to remove old poll prompt and append new one
         text_to_edit = base_announcement_text
         cleaned_text = base_announcement_text
-        # Try to find if an old prompt exists and remove it.
-        # This simple search might need to be more robust if text structure varies.
         logger.info(f"Original text for edit (before cleaning old prompt): \"{text_to_edit[:150]}...\"")
         for prompt_start_identifier in BOT_POLL_PROMPT_STARTS:
             if prompt_start_identifier in text_to_edit:
-                # Find the start of "\n\n" before the prompt start
-                # This is a heuristic to remove the previous prompt section
-                # A more robust way would be specific regex for each template or clear delimiters.
-                # For now, look for common patterns of how it might have been appended.
-                # This assumes the poll prompt was always appended with "\n\n".
                 parts = text_to_edit.split("\n\n" + prompt_start_identifier)
-                if len(parts) > 1: # Found and successfully split
-                    cleaned_text = parts[0] # Take text before the old prompt
+                if len(parts) > 1:
+                    cleaned_text = parts[0]
                     logger.info(f"Removed old poll prompt part starting with '{prompt_start_identifier}' from message {target_message_id_to_edit}. Cleaned text: \"{cleaned_text[:100]}...\"")
                     break
-                # Fallback for #опрос template which might start directly with <a href=
                 elif text_to_edit.startswith(prompt_start_identifier) and chosen_keyword_for_template == "#опрос":
-                    cleaned_text = "" # If the whole message was the #опрос prompt
+                    cleaned_text = ""
                     logger.info(f"Message {target_message_id_to_edit} seems to be an old #опрос prompt. Replacing with new. Cleaned text is now empty.")
                     break
 
@@ -324,13 +239,11 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
             logger.error(f"Error editing message {target_message_id_to_edit} in chat {TARGET_CHANNEL_ID}: {e}", exc_info=True)
             await message.reply_text(f"Sorry, I could not update the announcement with the poll link: {e}")
 
-        # No user_data to clear related to LAST_ANNOUNCEMENT_KEY anymore
         return
 
     logger.info(f"Message from user {user.id} (update ID: {update.update_id}) did not match keyword criteria or was not a poll. No action taken.")
 
 def main() -> None:
-    """Starts the bot (for local testing - Lambda will use a different entry point)."""
     if not TELEGRAM_BOT_TOKEN:
         logger.error("TELEGRAM_BOT_TOKEN environment variable not set!")
         return
@@ -342,7 +255,6 @@ def main() -> None:
     logger.info("Starting bot...")
     application = Application.builder().token(TELEGRAM_BOT_TOKEN).build()
     application.add_handler(CommandHandler("start", start))
-    # Combined handler for text and polls, routing to handle_message
     application.add_handler(MessageHandler(filters.TEXT | filters.POLL & ~filters.COMMAND, handle_message))
     logger.info("Bot polling started.")
     application.run_polling()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -4,10 +4,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 import sys
 
-# Ensure src is in path for imports
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../src')))
 
-# Set environment variables for testing BEFORE importing from main
 os.environ['TELEGRAM_BOT_TOKEN'] = 'test_token_pytest'
 os.environ['AUTHORIZED_USER_IDS'] = '123,456'
 os.environ['TARGET_CHANNEL_ID'] = '-100987654321'
@@ -17,11 +15,10 @@ from main import (
     AUTHORIZED_USER_IDS as MAIN_AUTHORIZED_USER_IDS,
     TARGET_CHANNEL_ID as MAIN_TARGET_CHANNEL_ID,
     KEYWORDS as MAIN_KEYWORDS,
-    POLL_LINK_MESSAGE_TEMPLATES, # Correctly named from main.py
-    POLL_CAPTION_IDENTIFIERS     # Correctly named from main.py
+    POLL_LINK_MESSAGE_TEMPLATES,
+    POLL_CAPTION_IDENTIFIERS
 )
 
-# Basic Sanity Checks
 assert MAIN_TARGET_CHANNEL_ID == '-100987654321'
 assert 123 in MAIN_AUTHORIZED_USER_IDS
 assert "#анонс" in MAIN_KEYWORDS and "#опрос" in MAIN_KEYWORDS
@@ -35,49 +32,39 @@ def mock_update_fixture():
     update = MagicMock(spec=Update)
     update.update_id = 12345
 
-    # Configure effective_user with actual string values for logging
     update.effective_user = MagicMock(spec=User)
     update.effective_user.id = 123
-    update.effective_user.username = "testuser"  # Actual string
-    update.effective_user.first_name = "Test"    # Actual string
-    update.effective_user.last_name = "User"     # Actual string
-    update.effective_user.full_name = "Test User" # Actual string
+    update.effective_user.username = "testuser"
+    update.effective_user.first_name = "Test"
+    update.effective_user.last_name = "User"
+    update.effective_user.full_name = "Test User"
     update.effective_user.is_bot = False
 
-    # Configure message and its chat with actual string/serializable values
     update.message = MagicMock(spec=Message)
     update.message.message_id = 789
     update.message.chat_id = 54321
-    update.message.date = datetime.datetime.now(datetime.timezone.utc) # Real datetime object
-    # message.date.isoformat() will be called by main.py, which is fine.
+    update.message.date = datetime.datetime.now(datetime.timezone.utc)
 
     update.message.text = None
     update.message.poll = None
     update.message.caption = None
 
     update.message.chat = MagicMock()
-    update.message.chat.type = "private" # Actual string
-    update.message.chat.title = None     # None is serializable
+    update.message.chat.type = "private"
+    update.message.chat.title = None
 
-    # Other message attributes if accessed by log_details (e.g., reply_to_message)
     update.message.reply_to_message = None
     update.message.forward_from = None
     update.message.forward_from_chat = None
-    # For "text_summary" in log_details, message.text is used. If None, it's fine.
-    # For "is_poll", "is_reply", "is_forwarded", these bool(mock) will be fine.
 
     update.message.reply_text = AsyncMock()
     return update
 
-# configured_forwarded_message_mock fixture is removed.
-
 @pytest.fixture
-def mock_context_fixture(): # No longer injects configured_forwarded_message_mock
+def mock_context_fixture():
     context = MagicMock(spec=ContextTypes.DEFAULT_TYPE)
     context.bot = AsyncMock(spec=Bot)
     context.bot.send_message = AsyncMock()
-    # bot.forward_message is now a plain AsyncMock.
-    # Tests will set its .return_value with a locally created mock.
     context.bot.forward_message = AsyncMock()
     context.bot.edit_message_caption = AsyncMock()
     context.bot.get_chat = AsyncMock()
@@ -86,10 +73,9 @@ def mock_context_fixture(): # No longer injects configured_forwarded_message_moc
     context.bot.get_chat.return_value = mock_chat_obj
     return context
 
-# --- General Tests ---
 @pytest.mark.asyncio
 async def test_handle_message_unauthorized_user(mock_update_fixture, mock_context_fixture):
-    mock_update_fixture.effective_user.id = 999 # Unauthorized
+    mock_update_fixture.effective_user.id = 999
     mock_update_fixture.message.text = f"{MAIN_KEYWORDS[0]} Some announcement"
     await handle_message(mock_update_fixture, mock_context_fixture)
     mock_context_fixture.bot.send_message.assert_not_called()
@@ -98,75 +84,60 @@ async def test_handle_message_unauthorized_user(mock_update_fixture, mock_contex
 
 @pytest.mark.asyncio
 async def test_handle_message_no_keyword_no_poll(mock_update_fixture, mock_context_fixture):
-    mock_update_fixture.effective_user.id = 123 # Authorized
+    mock_update_fixture.effective_user.id = 123
     mock_update_fixture.message.text = "Just a regular message"
     await handle_message(mock_update_fixture, mock_context_fixture)
     mock_context_fixture.bot.send_message.assert_not_called()
     mock_context_fixture.bot.forward_message.assert_not_called()
     mock_context_fixture.bot.edit_message_caption.assert_not_called()
 
-# --- Tests for Text Messages with Keywords (Commented out due to logger/mock interaction issue) ---
 # @pytest.mark.asyncio
 # @pytest.mark.parametrize("keyword_to_test", MAIN_KEYWORDS)
-# @patch('main.datetime.datetime') # For age check
+# @patch('main.datetime.datetime')
 # async def test_handle_text_message_with_keyword_sends_text_and_reply(
 #     mock_datetime_class, keyword_to_test, mock_update_fixture, mock_context_fixture
 # ):
 #     mock_update_fixture.effective_user.id = 123
 #     original_text = f"{keyword_to_test} This is a test announcement text."
 #     mock_update_fixture.message.text = original_text
-#     mock_update_fixture.message.poll = None # Not a poll
+#     mock_update_fixture.message.poll = None
 
-#     # --- Setup for age check (message is recent) ---
 #     current_time = datetime.datetime(2023, 10, 27, 12, 0, 0, tzinfo=datetime.timezone.utc)
 #     mock_datetime_class.now.return_value = current_time
 
-#     # Rebuild message mock for this test to ensure .date is a real datetime
 #     message_mock = MagicMock(spec=Message)
-#     # Copy essential attributes from the fixture's message mock if needed, or set fresh
 #     message_mock.message_id = mock_update_fixture.message.message_id
 #     message_mock.chat_id = mock_update_fixture.message.chat_id
 #     message_mock.reply_text = mock_update_fixture.message.reply_text
 #     message_mock.chat = mock_update_fixture.message.chat
 
-#     message_mock.text = original_text # Set by test
-#     message_mock.poll = None          # Set by test
+#     message_mock.text = original_text
+#     message_mock.poll = None
 
 #     recent_message_date = current_time - datetime.timedelta(minutes=5)
-#     message_mock.date = recent_message_date # Direct assignment of datetime object
+#     message_mock.date = recent_message_date
 
-#     mock_update_fixture.message = message_mock # Replace fixture's message
+#     mock_update_fixture.message = message_mock
 
-#     # --- Setup for bot's first message (the announcement) ---
 #     bot_announcement_message_mock = MagicMock(spec=Message)
-#     bot_announcement_message_mock.message_id = 2002 # ID of the bot's announcement
-#     # Simulate send_message returning this mock for the first call
+#     bot_announcement_message_mock.message_id = 2002
 
-#     # --- Setup for link generation to bot's announcement ---
-#     # mock_context_fixture.bot.get_chat already defaults to no username for target channel
-#     expected_channel_id_for_link = MAIN_TARGET_CHANNEL_ID[4:] # Strip "-100"
+#     expected_channel_id_for_link = MAIN_TARGET_CHANNEL_ID[4:]
 
-#     # Configure bot.send_message to return the announcement mock on the first call
-#     # and allow subsequent calls (for the reply)
 #     mock_context_fixture.bot.send_message.side_effect = [
-#         bot_announcement_message_mock, # Return for the first call (announcement)
-#         MagicMock(spec=Message)        # Return for the second call (reply)
+#         bot_announcement_message_mock,
+#         MagicMock(spec=Message)
 #     ]
 
 #     await handle_message(mock_update_fixture, mock_context_fixture)
 
-#     # Expected link to the bot's announcement message
 #     link_to_bot_announcement = f"https://t.me/{expected_channel_id_for_link}/{bot_announcement_message_mock.message_id}"
 
-#     # Determine expected prompt text
 #     prompt_template = POLL_LINK_MESSAGE_TEMPLATES.get(keyword_to_test, POLL_LINK_MESSAGE_TEMPLATES["#анонс"])
 #     expected_reply_text = prompt_template.format(link=link_to_bot_announcement)
 
-#     # Assert calls to bot.send_message
 #     calls = [
-#         # Call 1: The main announcement text
 #         call(chat_id=MAIN_TARGET_CHANNEL_ID, text=original_text),
-#         # Call 2: The reply with the "Проголосуй..." link
 #         call(chat_id=MAIN_TARGET_CHANNEL_ID,
 #              text=expected_reply_text,
 #              parse_mode='HTML',
@@ -176,30 +147,28 @@ async def test_handle_message_no_keyword_no_poll(mock_update_fixture, mock_conte
 #     mock_context_fixture.bot.send_message.assert_has_calls(calls, any_order=False)
 #     assert mock_context_fixture.bot.send_message.call_count == 2
 
-#     mock_context_fixture.bot.get_chat.assert_called_once_with(chat_id=MAIN_TARGET_CHANNEL_ID) # For link to bot's message
+#     mock_context_fixture.bot.get_chat.assert_called_once_with(chat_id=MAIN_TARGET_CHANNEL_ID)
 #     mock_context_fixture.bot.forward_message.assert_not_called()
 #     mock_context_fixture.bot.edit_message_caption.assert_not_called()
 
-# --- Tests for Poll Object Forwarding & Caption Editing (Commented out for now) ---
 # @pytest.mark.asyncio
 # @pytest.mark.parametrize("user_poll_caption_keyword, expected_template_key", [
-#     (MAIN_KEYWORDS[0], MAIN_KEYWORDS[0]),      # #анонс in caption -> #анонс template
-#     (MAIN_KEYWORDS[1], MAIN_KEYWORDS[1]),      # #опрос in caption -> #опрос template
-#     ("Some event", MAIN_KEYWORDS[0]),           # No specific keyword -> default #анонс
-#     (None, MAIN_KEYWORDS[0])                    # No caption -> default #анонс
+#     (MAIN_KEYWORDS[0], MAIN_KEYWORDS[0]),
+#     (MAIN_KEYWORDS[1], MAIN_KEYWORDS[1]),
+#     ("Some event", MAIN_KEYWORDS[0]),
+#     (None, MAIN_KEYWORDS[0])
 # ])
-# @patch('main.datetime.datetime') # More specific patch
+# @patch('main.datetime.datetime')
 # async def test_handle_poll_forwards_and_edits_caption(
 #     mock_datetime_class, user_poll_caption_keyword, expected_template_key,
 #     mock_update_fixture, mock_context_fixture
 # ):
-#     # Create and configure local mock for the forwarded message
 #     local_forwarded_message = MagicMock(spec=Message)
-#     local_forwarded_message.message_id = 1001 # Example ID
+#     local_forwarded_message.message_id = 1001
 
 #     mock_update_fixture.effective_user.id = 123
 #     mock_update_fixture.message.poll = MagicMock(spec=TelegramPoll)
-#     mock_update_fixture.message.text = user_poll_caption_keyword # User's poll caption
+#     mock_update_fixture.message.text = user_poll_caption_keyword
 
 #     current_time = datetime.datetime(2023, 10, 27, 12, 0, 0, tzinfo=datetime.timezone.utc)
 #     mock_datetime_class.now.return_value = current_time
@@ -304,7 +273,6 @@ async def test_handle_message_no_keyword_no_poll(mock_update_fixture, mock_conte
 #     mock_context_fixture.bot.edit_message_caption.assert_not_called()
 #     mock_context_fixture.bot.send_message.assert_not_called()
 
-# --- Error Handling Tests ---
 @pytest.mark.asyncio
 async def test_handle_text_message_no_target_channel_id(mock_update_fixture, mock_context_fixture):
     mock_update_fixture.effective_user.id = 123
@@ -324,7 +292,7 @@ async def test_handle_poll_no_target_channel_id(mock_update_fixture, mock_contex
     with patch('main.TARGET_CHANNEL_ID', ''):
         await handle_message(mock_update_fixture, mock_context_fixture)
     mock_update_fixture.message.reply_text.assert_called_once_with(
-        "Error: Target channel ID is not configured for polls." # Corrected expected message
+        "Error: Target channel ID is not configured for polls."
     )
     mock_context_fixture.bot.forward_message.assert_not_called()
     mock_context_fixture.bot.edit_message_caption.assert_not_called()


### PR DESCRIPTION
- Removed all inline comments from Python source files (`.py`).
- Updated README.md to reflect the comment removal strategy.
- Added a section to README.md under "Known Limitations and Important Notes" to highlight that the `find_bot_last_message_in_channel` function in `src/main.py` is a placeholder and requires a functional implementation for the poll-linking feature to work as intended.