### PR TITLE
Implement DynamoDB persistence for poll linking

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,8 +89,26 @@ Navigate to your GitHub repository's `Settings` > `Secrets and variables` > `Act
 *   `AWS_IAM_ROLE_FOR_GITHUB_ACTIONS`: The ARN of the IAM Role that GitHub Actions will assume to deploy to AWS.
 *   `TELEGRAM_BOT_TOKEN`: Your Telegram bot token obtained from BotFather.
 *   `TELEGRAM_WEBHOOK_SECRET_TOKEN`: A strong, random string used to verify webhook requests.
+*   `ANNOUNCEMENT_TABLE_NAME`: The name of the DynamoDB table used to store temporary announcement details for poll linking (e.g., `TelegramBotAnnouncements`).
 
-### 5. IAM Role for GitHub Actions (OIDC)
+### 5. DynamoDB Table for Announcements
+
+For the poll linking feature to work reliably across Lambda invocations, a DynamoDB table is used to store details of the last announcement made by a user.
+
+*   **Create a DynamoDB Table:**
+    *   **Table Name:** Choose a name (e.g., `TelegramBotAnnouncements`) and set this name as the `ANNOUNCEMENT_TABLE_NAME` environment variable for your Lambda function (see GitHub Repository Variables).
+    *   **Primary Key:** `user_id` (Number).
+    *   **Attributes (Example):**
+        *   `user_id` (Number) - Partition Key
+        *   `message_id` (Number)
+        *   `chat_id` (String or Number)
+        *   `text_content` (String)
+        *   `timestamp` (Number) - Unix timestamp
+        *   `ttl` (Number, Optional) - Unix timestamp for DynamoDB TTL to auto-delete old items.
+    *   Ensure you configure on-demand or provisioned capacity as appropriate for your expected load.
+    *   **Enable Time To Live (TTL):** It's recommended to enable TTL on the `ttl` attribute for automatic cleanup of stale records.
+
+### 6. IAM Role for GitHub Actions (OIDC)
 
 Create an IAM role in your AWS account that GitHub Actions can assume.
 *   **Trusted entity type**: Select "Web identity".

--- a/src/main.py
+++ b/src/main.py
@@ -1,8 +1,27 @@
 import os
 import logging
 import json
+import boto3 # Added for DynamoDB
 from telegram import Update, Bot
 from telegram.ext import Application, CommandHandler, MessageHandler, filters, ContextTypes
+
+# DynamoDB setup
+DYNAMODB_TABLE_NAME = os.environ.get('ANNOUNCEMENT_TABLE_NAME')
+dynamodb_resource = None
+announcement_table = None
+
+if DYNAMODB_TABLE_NAME:
+    try:
+        dynamodb_resource = boto3.resource('dynamodb')
+        announcement_table = dynamodb_resource.Table(DYNAMODB_TABLE_NAME)
+    except Exception as e:
+        # Log error during initialization, but allow bot to start if table is not critical for all ops
+        # Or handle more gracefully depending on how critical DynamoDB is for startup
+        logging.getLogger(__name__).error(f"Failed to initialize DynamoDB table {DYNAMODB_TABLE_NAME}: {e}", exc_info=True)
+        # Depending on requirements, might want to raise an exception here or set a flag
+else:
+    logging.getLogger(__name__).warning("ANNOUNCEMENT_TABLE_NAME environment variable not set. DynamoDB features will be disabled.")
+
 
 if __name__ == '__main__':
     logging.basicConfig(
@@ -12,7 +31,7 @@ if __name__ == '__main__':
 logger = logging.getLogger(__name__)
 
 import datetime
-from datetime import datetime as RealDatetimeClass
+from datetime import datetime as RealDatetimeClass # Renamed to avoid conflict with module name
 from datetime import timedelta
 import re
 import json
@@ -37,7 +56,7 @@ BOT_POLL_PROMPT_STARTS = [
     "<a href="
 ]
 
-LAST_ANNOUNCEMENT_KEY = 'last_announcement_details'
+# LAST_ANNOUNCEMENT_KEY = 'last_announcement_details' # No longer used with user_data for this
 
 async def start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     user_id = update.effective_user.id
@@ -45,16 +64,62 @@ async def start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     await update.message.reply_text('Hello! I am ready to monitor messages.')
     logger.info(f"Welcome message sent to user ID: {user_id}.")
 
-async def find_bot_last_message_in_channel(bot: Bot, channel_id: str, max_age_hours: int = 1, search_limit: int = 20) -> Optional[dict]:
-    logger.info(f"Searching for bot's last message in channel {channel_id} (search limit: {search_limit} messages, max age: {max_age_hours}h).")
-    bot_id = bot.id
-    try:
-        logger.warning(f"Message fetching part of find_bot_last_message_in_channel is a placeholder. It needs a real implementation.")
+async def find_bot_last_message_in_channel(user_id: int, bot: Bot, channel_id_to_match: str, max_age_hours: int = 1) -> Optional[dict]:
+    """
+    Finds the last announcement message details for a given user_id from DynamoDB.
+    Validates that the announcement was for the specified channel_id_to_match and within max_age_hours.
+    """
+    logger.info(f"Attempting to find last announcement for user_id {user_id} from DynamoDB.")
+
+    if not announcement_table:
+        logger.warning("DynamoDB table not available. Cannot find last announcement.")
         return None
 
+    try:
+        response = announcement_table.get_item(Key={'user_id': user_id})
     except Exception as e:
-        logger.error(f"Error trying to find bot's last message in channel {channel_id}: {e}", exc_info=True)
+        logger.error(f"Error fetching announcement from DynamoDB for user {user_id}: {e}", exc_info=True)
         return None
+
+    item = response.get('Item')
+    if not item:
+        logger.info(f"No announcement found in DynamoDB for user_id {user_id}.")
+        return None
+
+    # Validate if the announcement was for the expected channel
+    # Note: TARGET_CHANNEL_ID from env is usually a string. DynamoDB might store it as string or number.
+    # Ensure comparison is consistent or store TARGET_CHANNEL_ID in a consistent type.
+    # For now, assuming channel_id_to_match (from TARGET_CHANNEL_ID) is a string.
+    stored_channel_id = str(item.get('chat_id'))
+    if stored_channel_id != channel_id_to_match:
+        logger.warning(f"Stored announcement for user {user_id} was for channel {stored_channel_id}, expected {channel_id_to_match}. Ignoring.")
+        return None
+
+    stored_timestamp = item.get('timestamp')
+    if not isinstance(stored_timestamp, (int, float)): # DynamoDB stores numbers
+        logger.error(f"Invalid timestamp format in DynamoDB for user_id {user_id}: {stored_timestamp}")
+        return None
+
+    current_time_unix = int(RealDatetimeClass.now(datetime.timezone.utc).timestamp())
+    age_seconds = current_time_unix - stored_timestamp
+    max_age_seconds = max_age_hours * 60 * 60
+
+    if age_seconds > max_age_seconds:
+        logger.info(f"Last announcement for user {user_id} (timestamp: {stored_timestamp}) is older than {max_age_hours} hours. Current time: {current_time_unix}.")
+        # Optionally, consider deleting the stale record here if it wasn't cleared by TTL or successful poll linking
+        # try:
+        #     announcement_table.delete_item(Key={'user_id': user_id})
+        #     logger.info(f"Deleted stale announcement record for user {user_id} from DynamoDB.")
+        # except Exception as e_del:
+        #     logger.error(f"Error deleting stale announcement record for user {user_id}: {e_del}", exc_info=True)
+        return None
+
+    logger.info(f"Found recent announcement for user {user_id} in DynamoDB: message_id {item.get('message_id')}")
+    return {
+        'message_id': int(item.get('message_id')), # Ensure it's int
+        'text_content': item.get('text_content'),
+        'timestamp': stored_timestamp # Return the original stored timestamp
+    }
 
 
 async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
@@ -121,6 +186,30 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
                 logger.info(f"Posting text announcement to {TARGET_CHANNEL_ID}: \"{text_to_repost[:100]}...\"")
                 posted_announcement = await context.bot.send_message(chat_id=TARGET_CHANNEL_ID, text=text_to_repost)
                 logger.info(f"Successfully posted text announcement with ID {posted_announcement.message_id}.")
+
+                # Store announcement details in DynamoDB
+                if announcement_table:
+                    user_id = user.id
+                    current_timestamp = int(RealDatetimeClass.now(datetime.timezone.utc).timestamp())
+                    # TTL for 24 hours from now
+                    ttl_timestamp = current_timestamp + (24 * 60 * 60)
+
+                    announcement_item = {
+                        'user_id': user_id,
+                        'message_id': posted_announcement.message_id,
+                        'chat_id': TARGET_CHANNEL_ID, # Assuming TARGET_CHANNEL_ID is string, convert if necessary for consistency
+                        'text_content': text_to_repost,
+                        'timestamp': current_timestamp,
+                        'ttl': ttl_timestamp
+                    }
+                    try:
+                        announcement_table.put_item(Item=announcement_item)
+                        logger.info(f"Stored announcement details for user {user_id} in DynamoDB: message_id {posted_announcement.message_id}")
+                    except Exception as db_e:
+                        logger.error(f"Failed to store announcement details in DynamoDB for user {user_id}: {db_e}", exc_info=True)
+                else:
+                    logger.warning("DynamoDB table not available. Cannot store announcement details.")
+
             except Exception as e:
                 logger.error(f"Error posting text announcement for keyword '{found_keyword_in_text}': {e}", exc_info=True)
                 await message.reply_text(f"Sorry, error posting your announcement: {e}")
@@ -142,12 +231,18 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
             logger.info(f"Original poll (ID: {message.message_id}) is older than 1 hour. Skipping poll prompt.")
             return
 
-        logger.info(f"Attempting to find bot's last message in channel {TARGET_CHANNEL_ID} to attach poll link.")
+        logger.info(f"Attempting to find bot's last message in channel {TARGET_CHANNEL_ID} to attach poll link for user {user.id}.")
+
+        # Ensure user object and id are available
+        if not user or not user.id:
+            logger.error(f"User information not available in poll handler. Cannot proceed to find last announcement.")
+            return
 
         last_bot_message_details = await find_bot_last_message_in_channel(
-            bot=context.bot,
-            channel_id=TARGET_CHANNEL_ID,
-            max_age_hours=1
+            user_id=user.id, # Pass user_id
+            bot=context.bot, # bot object
+            channel_id_to_match=TARGET_CHANNEL_ID, # The channel to match against stored record
+            max_age_hours=1 # Or whatever configured value is appropriate
         )
 
         if not last_bot_message_details:
@@ -235,6 +330,17 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
         try:
             await context.bot.edit_message_text(**edit_params)
             logger.info(f"Successfully edited message {target_message_id_to_edit} in chat {TARGET_CHANNEL_ID} with new poll prompt.")
+
+            # Clear the announcement details from DynamoDB after successful edit
+            if announcement_table:
+                try:
+                    announcement_table.delete_item(Key={'user_id': user.id})
+                    logger.info(f"Successfully deleted announcement details from DynamoDB for user {user.id}.")
+                except Exception as db_del_e:
+                    logger.error(f"Error deleting announcement details from DynamoDB for user {user.id}: {db_del_e}", exc_info=True)
+            else:
+                logger.warning("DynamoDB table not available. Cannot delete announcement details.")
+
         except Exception as e:
             logger.error(f"Error editing message {target_message_id_to_edit} in chat {TARGET_CHANNEL_ID}: {e}", exc_info=True)
             await message.reply_text(f"Sorry, I could not update the announcement with the poll link: {e}")

--- a/template.yaml
+++ b/template.yaml
@@ -18,6 +18,9 @@ Parameters:
     Type: String
     Description: "A secret token used to verify webhook requests from Telegram. Should be a long random string."
     NoEcho: true
+  AnnouncementTableName:
+    Type: String
+    Description: "Name of the DynamoDB table for storing announcement details (e.g., TelegramBotAnnouncements)"
 
 Globals:
   Function:
@@ -40,6 +43,10 @@ Resources:
           AUTHORIZED_USER_IDS: !Ref AuthorizedUserIds
           TARGET_CHANNEL_ID: !Ref TargetChannelId
           TELEGRAM_WEBHOOK_SECRET_TOKEN: !Ref TelegramWebhookSecretToken
+          ANNOUNCEMENT_TABLE_NAME: !Ref AnnouncementTableName
+      Policies:
+        - DynamoDBCrudPolicy:
+            TableName: !Ref AnnouncementTableName
       Events:
         TelegramWebhook:
           Type: Api


### PR DESCRIPTION
- Integrate AWS SDK (boto3) for DynamoDB operations.
- Store announcement message_id, text, and timestamp in DynamoDB, keyed by user_id, upon successful announcement.
- Modify find_bot_last_message_in_channel to fetch these details from DynamoDB, validating age and channel.
- Update handle_message to clear DynamoDB entry after successfully linking a poll to an announcement.
- Update README.md and template.yaml to reflect new DynamoDB table requirement, ANNOUNCEMENT_TABLE_NAME environment variable, and necessary IAM permissions for the Lambda function.